### PR TITLE
Fix: removed HOME environment variable 

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -49,8 +49,6 @@ parts:
 
 apps:
   logseq:
-    environment:
-      HOME: $SNAP_REAL_HOME
     command: app/Logseq --no-sandbox
     extensions:
       - gnome


### PR DESCRIPTION
The `HOME: $SNAP_REAL_HOME` shouldn't be needed by personal-files plug (check https://snapcraft.io/docs/personal-files-interface).

It's messing with permissions over logseq's user configuration files.