### PR TITLE
Change: fix can build pipeline with plug declarion file

### DIFF
--- a/.github/workflows/test-snap-can-build.yml
+++ b/.github/workflows/test-snap-can-build.yml
@@ -18,6 +18,5 @@ jobs:
         with:
           snap: ${{ steps.build.outputs.snap }}
           isClassic: 'false'
-          # Plugs and Slots declarations to override default denial (requires store assertion to publish)
-          # plugs: ./plug-declaration.json
+          plugs: ./plug-declaration.json
           # slots: ./slot-declaration.json

--- a/plug-declaration.json
+++ b/plug-declaration.json
@@ -1,0 +1,4 @@
+{
+    "system-files": {"allow-installation": true},
+    "personal-files": {"allow-installation": true}
+}


### PR DESCRIPTION
The `snap-review` tools is used in the `test-snap-can-build` pipeline to perform the same tests that are run when one want to publish a new revision of the snap.

Since we got approval of a subset of `system-files` and `personal-files` (see https://forum.snapcraft.io/t/auto-connect-request-for-logseq/37236/), I added a `plug-declaration.json` file to declare that.