### PR TITLE
Add: audio-playback interface for embedded video player

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -59,6 +59,7 @@ apps:
       - etc-gitconfig
       - gitconfig
       - ssh-keys
+      - audio-playback
 
 plugs:
   shmem:


### PR DESCRIPTION
Logseq provides a way to embed YouTube videos and similar to the journal. For `script` snap that means connecting to the `audio-playback` interface.

Fixes https://github.com/p-gentili/logseq/issues/7