### PR TITLE
Change: rounded SVG icon

### DIFF
--- a/snap/gui/icon.svg
+++ b/snap/gui/icon.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="128" height="128" version="1.1" viewBox="0 0 33.867 33.867" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <filter id="filter32698" x="-.033044" y="-.033044" width="1.0799" height="1.0799" color-interpolation-filters="sRGB">
+      <feFlood flood-color="rgb(0,0,0)" flood-opacity=".49804" result="flood"/>
+      <feComposite in="flood" in2="SourceGraphic" operator="in" result="composite1"/>
+      <feGaussianBlur in="composite1" result="blur" stdDeviation="3"/>
+      <feOffset dx="3" dy="3" result="offset"/>
+      <feComposite in="SourceGraphic" in2="offset" result="composite2"/>
+    </filter>
+  </defs>
+  <g transform="matrix(.14394 0 0 .14361 14.231 14.634)" filter="url(#filter32698)">
+    <rect x="-91.67" y="-94.693" width="217.89" height="217.89" ry="49.84" fill="#002b34"/>
+    <g fill="#86c8c8">
+      <ellipse transform="matrix(.66125 .75016 -.77588 .63088 0 0)" cx="-57.519" cy="10.486" rx="31.704" ry="28.51"/>
+      <ellipse transform="matrix(.97857 -.2059 .18878 .98202 0 0)" cx="38.904" cy="-43.706" rx="29.936" ry="18.529"/>
+      <ellipse transform="matrix(.99984 .01773 -.025088 .99969 0 0)" cx="37.271" cy="45.715" rx="70.546" ry="54.909"/>
+    </g>
+  </g>
+</svg>

--- a/snap/gui/logseq.desktop
+++ b/snap/gui/logseq.desktop
@@ -3,5 +3,5 @@ Name=Logseq Desktop
 Exec=logseq %U
 Terminal=false
 Type=Application
-Icon=${SNAP}/app/resources/app/icon.png
+Icon=${SNAP}/snap/gui/icon.svg
 Categories=Utility


### PR DESCRIPTION
Like proposed by https://github.com/p-gentili/logseq/pull/5 but with using a nice SVG instead. Thanks to the Flatpak maintainer for it (https://github.com/flathub/com.logseq.Logseq).