### PR TITLE
Change: instead of pushing on master create a PR

### DIFF
--- a/.github/workflows/auto-update.yaml
+++ b/.github/workflows/auto-update.yaml
@@ -18,4 +18,4 @@ jobs:
         uses: ubuntu/desktop-snaps@stable
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          repo: ${{ github.repository }}
+          repo: https://api.github.com/repos/${{ github.repository }}/pulls

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,7 +13,7 @@ parts:
     plugin: nil
     source: https://github.com/logseq/logseq.git
     source-depth: 1
-    source-tag: '0.9.19'
+    source-tag: '0.9.20'
     build-packages:
       - curl
       - default-jdk


### PR DESCRIPTION
Being a protected branch, the auto-update workflow is failing to push to master. It should create a PR instead.