### PR TITLE
Add: removable-media add to save files on ext disks

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -62,6 +62,7 @@ apps:
       - gitconfig
       - ssh-keys
       - audio-playback
+      - removable-media
 
 plugs:
   shmem:


### PR DESCRIPTION
Hello! I want to use Logseq snap version, but with saving files on removable media such as non-system drives. I built the package in docker and was able to test it successfully in ubuntu 22.04.