### PR TITLE
Change: update node version as upstream

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -30,7 +30,7 @@ parts:
       set -x
 
       # Install node
-      curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
+      curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
       apt-get install -y nodejs
 
       # Install clojure at required version


### PR DESCRIPTION
Updated node version as for https://github.com/logseq/logseq/commit/93bb8ac224dec961c8cec52e246360830725ae20