### PR TITLE
Support for logseq-og track

### DIFF
--- a/.github/workflows/auto-update.yaml
+++ b/.github/workflows/auto-update.yaml
@@ -13,9 +13,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout this repo
-        uses: actions/checkout@v3
-      - name: Run desktop-snaps action
-        uses: ubuntu/desktop-snaps@stable
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+
+      - name: Update snapcraft.yaml
+        uses: ubuntu/desktop-snaps@12a322bc9b39889b93b71ffa2a1a1b2f0932cff5 # stable
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repo: ${{ github.repository }}
+          yaml-path: snap/snapcraft.yaml
+
+      - name: Update legacy (og) snapcraft.yaml
+        uses: ubuntu/desktop-snaps@12a322bc9b39889b93b71ffa2a1a1b2f0932cff5 # stable
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repo: ${{ github.repository }}
+          yaml-path: snap-og/snap/snapcraft.yaml

--- a/.github/workflows/push-snap.yml
+++ b/.github/workflows/push-snap.yml
@@ -6,20 +6,54 @@ on:
   workflow_dispatch:
 
 jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      projects: ${{ steps.set.outputs.projects }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - if: github.event_name != 'workflow_dispatch'
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
+        id: filter
+        with:
+          filters: |
+            snap:
+              - 'snap/**'
+            snap-og:
+              - 'snap-og/**'
+
+      - id: set
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo 'projects=["snap","snap-og"]' >> "$GITHUB_OUTPUT"
+          else
+            echo 'projects=${{ steps.filter.outputs.changes }}' >> "$GITHUB_OUTPUT"
+          fi
+
   build-and-publish:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.projects != '[]'
     strategy:
       fail-fast: false
       matrix:
+        project: ${{ fromJSON(needs.detect-changes.outputs.projects) }}
         runner: [ubuntu-24.04, ubuntu-24.04-arm]
 
     runs-on: "${{ matrix.runner }}"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: snapcore/action-build@v1
+      - uses: snapcore/action-build@3bdaa03e1ba6bf59a65f84a751d943d549a54e79 # v1
         id: build
+        with:
+          path: ${{ matrix.project == 'snap' && '.' || matrix.project }}
 
-      - uses: snapcore/action-publish@v1
+      - if: matrix.project == 'snap-og'
+        run: echo "Skipping publish for snap-og — og track not yet provisioned (built ${{ steps.build.outputs.snap }})"
+
+      - if: matrix.project != 'snap-og'
+        uses: snapcore/action-publish@214b86e5ca036ead1668c79afb81e550e6c54d40 # v1
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
         with:

--- a/.github/workflows/test-snap-can-build.yml
+++ b/.github/workflows/test-snap-can-build.yml
@@ -5,20 +5,40 @@ on:
     branches: [ main ]
 
 jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      projects: ${{ steps.filter.outputs.changes }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
+        id: filter
+        with:
+          filters: |
+            snap:
+              - 'snap/**'
+            snap-og:
+              - 'snap-og/**'
+
   build-and-check:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.projects != '[]'
     strategy:
       fail-fast: false
       matrix:
+        project: ${{ fromJSON(needs.detect-changes.outputs.projects) }}
         runner: [ubuntu-24.04, ubuntu-24.04-arm]
 
     runs-on: "${{ matrix.runner }}"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: snapcore/action-build@v1
+      - uses: snapcore/action-build@3bdaa03e1ba6bf59a65f84a751d943d549a54e79 # v1
         id: build
+        with:
+          path: ${{ matrix.project == 'snap' && '.' || matrix.project }}
 
-      - uses: diddlesnaps/snapcraft-review-action@v1
+      - uses: diddlesnaps/snapcraft-review-action@40554b42331cf84dab19ef98c382620427f13482 # v1
         with:
           snap: ${{ steps.build.outputs.snap }}
           isClassic: 'false'

--- a/snap-og/snap/gui/icon.svg
+++ b/snap-og/snap/gui/icon.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="128" height="128" version="1.1" viewBox="0 0 33.867 33.867" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <filter id="filter32698" x="-.033044" y="-.033044" width="1.0799" height="1.0799" color-interpolation-filters="sRGB">
+      <feFlood flood-color="rgb(0,0,0)" flood-opacity=".49804" result="flood"/>
+      <feComposite in="flood" in2="SourceGraphic" operator="in" result="composite1"/>
+      <feGaussianBlur in="composite1" result="blur" stdDeviation="3"/>
+      <feOffset dx="3" dy="3" result="offset"/>
+      <feComposite in="SourceGraphic" in2="offset" result="composite2"/>
+    </filter>
+  </defs>
+  <g transform="matrix(.14394 0 0 .14361 14.231 14.634)" filter="url(#filter32698)">
+    <rect x="-91.67" y="-94.693" width="217.89" height="217.89" ry="49.84" fill="#002b34"/>
+    <g fill="#86c8c8">
+      <ellipse transform="matrix(.66125 .75016 -.77588 .63088 0 0)" cx="-57.519" cy="10.486" rx="31.704" ry="28.51"/>
+      <ellipse transform="matrix(.97857 -.2059 .18878 .98202 0 0)" cx="38.904" cy="-43.706" rx="29.936" ry="18.529"/>
+      <ellipse transform="matrix(.99984 .01773 -.025088 .99969 0 0)" cx="37.271" cy="45.715" rx="70.546" ry="54.909"/>
+    </g>
+  </g>
+</svg>

--- a/snap-og/snap/gui/logseq.desktop
+++ b/snap-og/snap/gui/logseq.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Name=Logseq Desktop
+Exec=logseq %U
+Terminal=false
+Type=Application
+Icon=${SNAP}/snap/gui/icon.svg
+Categories=Utility

--- a/snap-og/snap/snapcraft.yaml
+++ b/snap-og/snap/snapcraft.yaml
@@ -1,0 +1,79 @@
+name: logseq
+base: core22
+adopt-info: logseq
+summary: Logseq is a privacy-first, open-source knowledge base.
+description: |
+  Logseq is a privacy-first, open-source knowledge base that works on top of local plain-text Markdown and Org-mode files. Use it to write, organize and share your thoughts, keep your to-do list, and build your own digital garden.
+
+grade: stable
+confinement: strict
+
+parts:
+  logseq:
+    plugin: nil
+    source: https://github.com/logseq/og.git
+    source-depth: 1
+    source-tag: '1.0.0'
+    build-packages:
+      - curl
+      - default-jdk
+      - libgif-dev
+      - zip
+    stage-packages:
+      - libnss3
+      - libnspr4
+
+    override-pull: |
+      craftctl default
+      craftctl set version=$(git describe --tags)
+
+      set -x
+
+      # Install node
+      curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
+      apt-get install -y nodejs
+
+      # Install clojure at required version
+      curl -fsSL https://download.clojure.org/install/linux-install-1.11.1.1413.sh | bash -
+
+    override-build: |
+      craftctl default
+
+      set -x
+
+      npm install --global yarn
+      yarn config set network-timeout 1000000
+      yarn install
+
+      yarn cljs:release && yarn release-electron &&\
+      mv ./static/out/Logseq-linux-* $SNAPCRAFT_PART_INSTALL/app &&\
+      chmod 755 $SNAPCRAFT_PART_INSTALL/app
+
+apps:
+  logseq:
+    command: app/Logseq --no-sandbox
+    extensions:
+      - gnome
+    plugs:
+      - network
+      - shmem
+      - home
+      - etc-gitconfig
+      - gitconfig
+      - ssh-keys
+      - audio-playback
+      - removable-media
+
+plugs:
+  shmem:
+    interface: shared-memory
+    private: true
+  etc-gitconfig:
+    interface: system-files
+    read:
+    - /etc/gitconfig
+  gitconfig:
+    interface: personal-files
+    read:
+    - $HOME/.gitconfig
+    - $HOME/.config/git/config

--- a/snap-og/snap/snapcraft.yaml
+++ b/snap-og/snap/snapcraft.yaml
@@ -46,12 +46,12 @@ parts:
       yarn install
 
       yarn cljs:release && yarn release-electron &&\
-      mv ./static/out/Logseq-linux-* $SNAPCRAFT_PART_INSTALL/app &&\
+      mv ./static/out/Logseq-OG-linux-* $SNAPCRAFT_PART_INSTALL/app &&\
       chmod 755 $SNAPCRAFT_PART_INSTALL/app
 
 apps:
   logseq:
-    command: app/Logseq --no-sandbox
+    command: app/Logseq-OG --no-sandbox
     extensions:
       - gnome
     plugs:


### PR DESCRIPTION
Reference: https://logseq.io/page/b2ad9ce1-9cb7-4436-8083-54cb4516d324/df4dc09d-0a12-4c87-904e-22a9bf4c350a
Track creation request: https://forum.snapcraft.io/t/request-track-creation-for-logseq/51208

tl;dr: the logseq team is splitting the project in two: maintenance mode for the current version (now called `og`), main application with focus on the database version.