### PR TITLE
enable pushing to the og channel

### DIFF
--- a/.github/workflows/push-snap.yml
+++ b/.github/workflows/push-snap.yml
@@ -50,7 +50,12 @@ jobs:
           path: ${{ matrix.project == 'snap' && '.' || matrix.project }}
 
       - if: matrix.project == 'snap-og'
-        run: echo "Skipping publish for snap-og — og track not yet provisioned (built ${{ steps.build.outputs.snap }})"
+        uses: snapcore/action-publish@214b86e5ca036ead1668c79afb81e550e6c54d40 # v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
+        with:
+          snap: ${{ steps.build.outputs.snap }}
+          release: og/edge
 
       - if: matrix.project != 'snap-og'
         uses: snapcore/action-publish@214b86e5ca036ead1668c79afb81e550e6c54d40 # v1

--- a/README.md
+++ b/README.md
@@ -33,3 +33,26 @@ sudo snap connect logseq:ssh-keys
 [![Get it from the Snap Store](https://snapcraft.io/static/images/badges/en/snap-store-black.svg)](https://snapcraft.io/logseq)
 
 ([Don't have snapd installed?](https://snapcraft.io/docs/core/install))
+
+## Logseq OG
+
+[Logseq OG](https://github.com/logseq/og) is the original, file-based version of Logseq
+that works on top of local plain-text Markdown and Org-mode files. It's preserved for users
+who prefer it over the newer database-based release. It's published to the `og` track of this
+same snap, so you can run it without affecting your default Logseq install. To install it:
+
+```bash
+sudo snap install logseq --channel=og
+```
+
+If you already have Logseq installed, switch to it with:
+
+```bash
+sudo snap refresh logseq --channel=og
+```
+
+To go back to the default release, refresh to the `latest` track:
+
+```bash
+sudo snap refresh logseq --channel=latest
+```


### PR DESCRIPTION
The snap store team has created the `og` track: we can start using it.